### PR TITLE
Add nginx reverse proxy

### DIFF
--- a/deployments/nginx-proxy.yml
+++ b/deployments/nginx-proxy.yml
@@ -1,0 +1,29 @@
+kind: Deployment
+apiVersion: extensions/v1beta1
+metadata:
+  name: nginx-proxy
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        component: proxy
+    spec:
+      containers:
+        - name: nginx
+          image: gcr.io/mitlib-adit/nginx-proxy:0.0.1.3
+          env:
+            - name: FEDORA_USER
+              valueFrom:
+                secretKeyRef:
+                  name: fedora
+                  key: username
+            - name: FEDORA_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: fedora
+                  key: password
+          ports:
+            - containerPort: 80
+              name: http
+              protocol: TCP

--- a/services/fedora.yml
+++ b/services/fedora.yml
@@ -3,7 +3,6 @@ apiVersion: v1
 metadata:
   name: fedora
 spec:
-  type: LoadBalancer
   selector:
     component: repository
   ports:

--- a/services/nginx-proxy.yml
+++ b/services/nginx-proxy.yml
@@ -1,0 +1,12 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: nginx-proxy
+spec:
+  type: LoadBalancer
+  selector:
+    component: proxy
+  ports:
+    - name: http
+      port: 80
+      protocol: TCP


### PR DESCRIPTION
This puts the fedora instance behind nginx with basic auth. Note that
this is still running over http, so the password is in the clear.