### PR TITLE
Upgrade Elasticsearch to version 5

### DIFF
--- a/deployments/elasticsearch.yml
+++ b/deployments/elasticsearch.yml
@@ -8,10 +8,21 @@ spec:
     metadata:
       labels:
         component: elasticsearch
+      annotations:
+        pod.beta.kubernetes.io/init-containers: '[
+          {
+            "name": "sysctl",
+            "image": "busybox",
+            "command": ["sysctl", "-w", "vm.max_map_count=262144"],
+            "securityContext": {
+              "privileged": true
+            }
+          }
+        ]'
     spec:
       containers:
       - name: elasticsearch
-        image: elasticsearch:2
+        image: gcr.io/mitlib-adit/elastic:0.0.1
         ports:
           - containerPort: 9200
             name: http


### PR DESCRIPTION
There are a few reasons why this seems more complicated than it should
be. Elasticsearch 5 needs a higher `vm.max_map_count` on the host than
is set by default. A privileged init container is used to set this. The
official Elasticsearch 5 image has x-pack enabled by default. This can
be disabled by passing environment variables, but the environment
variable names have a period in them and kubernetes does not allow this.
A custom Elasticsearch image is used for the sole reason of disabling
x-pack.